### PR TITLE
Fix/dependencies and issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,30 +10,7 @@ media
 
 # If you are using PyCharm # 
 # User-specific stuff
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
-
-# AWS User-specific
-.idea/**/aws.xml
-
-# Generated files
-.idea/**/contentModel.xml
-
-# Sensitive or high-churn files
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
-
-# Gradle
-.idea/**/gradle.xml
-.idea/**/libraries
+.idea/
 
 # File-based project format
 *.iws
@@ -135,3 +112,7 @@ GitHub.sublime-settings
 !.vscode/launch.json 
 !.vscode/extensions.json 
 .history
+
+# Local databases
+*.sqlite
+*.sqlite3

--- a/hotel/tests/tests.py
+++ b/hotel/tests/tests.py
@@ -5,8 +5,6 @@ from hotel.models import Stay, Hotel, Guest
 from hotel.tests import load_api_fixture
 from hotel.tests.factories import HotelFactory
 
-from hotel.pms_systems import CleanedWebhookPayload
-
 
 class PMS_Apaleotest(django.test.TestCase):
     def setUp(self) -> None:
@@ -22,7 +20,7 @@ class PMS_Apaleotest(django.test.TestCase):
         if not cleaned_payload:
             self.fail("No cleaned payload returned")
         else:
-            self.assertIsInstance(cleaned_payload, CleanedWebhookPayload)
+            self.assertIsInstance(cleaned_payload, dict)
             self.assertEqual(cleaned_payload["hotel_id"], self.hotel.id)
             self.assertIsInstance(cleaned_payload["data"], dict)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Django==4.2.2
+factory-boy==3.3.3


### PR DESCRIPTION
1. Added missing dependency `factory-boy`

2. Replaced all `.idea/*` files in `.gitignore` with `.idea` because different developers might have different IDE plugins installed and it's easier to ignore entire `.idea` folder that adding all possible files that need to be ignored

3. Changed the type validation in the test from
```
self.assertIsInstance(cleaned_payload, CleanedWebhookPayload)
```
to
```
self.assertIsInstance(cleaned_payload, dict)
```
because the assertion is failing with the error 
```
TypedDict does not support instance and class checks
```
and according to [Stackoverflow discussion](https://stackoverflow.com/questions/74850561/python-3-10-8-typeerror-typeddict-does-not-support-instance-and-class-checks):

> ... seems like an issue with the typeguard library (a crucial details) which seems to rely on the type annotations being actual types, but TypeDict is not, it exists merely for type hinting.
